### PR TITLE
Fix build on OS X with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 PROJECT = oneup
 
 CC = g++ 
-CFLAGS ?= -O3 -std=c++11 -finline-functions -Wall
+OS := $(shell uname)
+ifeq ($(OS), Darwin)
+    CFLAGS ?= -O3 -std=c++11 -Wl,-undefined,dynamic_lookup -Wall
+else
+    CFLAGS ?= -O3 -std=c++11 -finline-functions -Wall
+endif
 
 include erlang.mk
 


### PR DESCRIPTION
This makes it possible to build on recent OS X. Tested with El Capitan and Ubuntu 16.04 LTS.

-finline-functions is removed in clang.
-undefined,dynamic_lookup linker option is needed to suppress errors about the missing ei functions.
