### PR TITLE
Make oneup compilable as rebar dependency and introduce priv_path env var for NIF loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@ deps
 *.o
 *.beam
 *.plt
+*.iml
 erl_crash.dump
 ebin
 rel/example_project
 .concrete/DEV_MODE
 .rebar
 priv
+_build
 c_src/env.mk

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,8 @@
+{erl_opts, [debug_info]}.
+{deps, []}.
+
+{pre_hooks,
+  [{compile, "make all"}]}.
+{post_hooks,
+  [{clean, "make clean"}]}.
+


### PR DESCRIPTION
Make oneup compilable as rebar dependency and loadable from escript by introducing priv_path as env var now used during NIF loading.  
 It was tested as rebar dependency inside a couple of escripts that use oneup (I had to manually run make all from _build/default/lib/oneup at first)  However with addition of this rebar.config, priv/oneup.so was created during `rebar3 escriptize` of the dependent script.   Also loaded no problem after `-oneup priv_path \"_build/default/lib/oneup/priv\"` was added to the escript's rebar.config escript_emu_args