### PR TITLE
Make atomic counter setter available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@ deps
 *.o
 *.beam
 *.plt
+*.iml
 erl_crash.dump
 ebin
 rel/example_project
 .concrete/DEV_MODE
 .rebar
 priv
+_build
 c_src/env.mk

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Create a new counter. This returns a reference that is required for further oneu
 C = oneup:new_counter().
 ```
 
-Increment the counter. Any number of processes can safely increment a counter. A 64 bit signed long is used to hold the value, not an erlang auto number. The maximum value is (2^31-1) or less depending on architecture.
+Increment or set the counter. Any number of processes can safely increment or set a counter. A 64 bit signed long is used to hold the value, not an erlang auto number. The maximum value is (2^31-1) or less depending on architecture.
 
 ```erlang
 ok = oneup:inc(C).
 ok = oneup:inc2(C, 10).
+ok = oneup:set(C, 200).
 ```
 
 Retrieve the result. Any number of processes can safely read a counter.

--- a/c_src/oneup.cc
+++ b/c_src/oneup.cc
@@ -107,6 +107,26 @@ inc2(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 }
 
 static ERL_NIF_TERM
+set(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    std::atomic<long> *value;
+    long int new_value;
+
+    if(argc != 2) {
+        return enif_make_badarg(env);
+    }
+    if(!enif_get_resource(env, argv[0], ONEUP_RESOURCE_TYPE, (void**) &value)) {
+        return enif_make_badarg(env);
+    }
+    if(!enif_get_long(env, argv[1], &new_value)) {
+        return enif_make_badarg(env);
+    }
+    value->operator=((long) new_value);
+
+    return ATOM_OK;
+}
+
+static ERL_NIF_TERM
 inc_if_less_than(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     std::atomic<long> *value;
@@ -179,6 +199,7 @@ static ErlNifFunc nif_funcs[] = {
     {"get", 1, get},
     {"inc", 1, inc},
     {"inc2", 2, inc2},
+    {"set", 2, set},
     {"inc_if_less_than", 3, inc_if_less_than},
     {"is_lock_free", 0, is_lock_free},
     {"new_counter", 0, new_counter},

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,8 @@
+{erl_opts, [debug_info]}.
+{deps, []}.
+
+{pre_hooks,
+  [{compile, "make all"}]}.
+{post_hooks,
+  [{clean, "make clean"}]}.
+


### PR DESCRIPTION
This solves issue https://github.com/andytill/oneup/issues/2
`oneup:set(Counter, Value)` is made available (it was tested and benchmarked with results similar to `inc`:
oneup:oneup_inc in 0.003652s
oneup:oneup_concurrent_inc in 0.028007s
oneup:oneup_set in 0.003875s
oneup:oneup_concurrent_set in 0.019463s
