### PR TITLE
Update set to return prev value.   Add set_min and set_max methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Set min or max.
 Retrieve the result. Any number of processes can safely read a counter.
 
 ```erlang
-11 = oneup:get(C).
+200 = oneup:get(C).
 ```
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -16,18 +16,27 @@ Create a new counter. This returns a reference that is required for further oneu
 C = oneup:new_counter().
 ```
 
-Increment or set the counter. Any number of processes can safely increment or set a counter. A 64 bit signed long is used to hold the value, not an erlang auto number. The maximum value is (2^31-1) or less depending on architecture.
+Increment or set the counter. Any number of processes can safely increment or set a counter. A 64 bit signed long is used to hold the value, not an erlang auto number. The maximum value is (2^63-1) or less depending on architecture.
 
 ```erlang
-ok = oneup:inc(C).
-ok = oneup:inc2(C, 10).
-ok = oneup:set(C, 200).
+ok = oneup:inc(C). %% value of C becomes 1
+ok = oneup:inc2(C, 10).  %% value of C becomes 11
+11 = oneup:set(C, 200). %% set to 200 and return previous value
+```
+
+Set min or max. 
+
+```
+300 = oneup:set_max(C, 300). %% set to max of current and new value and return max
+300 = oneup:set_max(C, 100).
+100 = oneup:set_min(C, 100). %% set to min of current and new value and return min
+100 = oneup:set_min(C, 300).
 ```
 
 Retrieve the result. Any number of processes can safely read a counter.
 
 ```erlang
-11 = oneup:get().
+11 = oneup:get(C).
 ```
 
 ### Performance


### PR DESCRIPTION
`set` was modified to return previous value.   (great and harmless addition for atomic resets during ticks inside metric libraries)
`set_min` and `set_max` are as good (or as bad) as `inc_if_less_than` already available in oneup.   (Very useful for lightweight reservoir-less histograms)

`set_min` sets and returns whichever is smaller current value or new value
`set_max` sets and returns whichever is larger, current value or new value
