### PR TITLE
Get rid of io:format() calls

### DIFF
--- a/src/oneup.erl
+++ b/src/oneup.erl
@@ -112,7 +112,6 @@ init() ->
                 end;
             SoNameFromEnv when is_list(SoNameFromEnv) -> SoNameFromEnv
         end,
-    io:format("Loading ~p~n", [SoName]),
     erlang:load_nif(SoName, 0).
 
 priv_path_env()->
@@ -126,7 +125,7 @@ priv_path_env()->
         _NotFound -> undefined
       end;
     {ok, InvalidPrivPath} ->
-      io:format("Expected priv_path env as string got ~p~n", [InvalidPrivPath]),
+      error_logger:format("Expected priv_path env as string got ~p", [InvalidPrivPath]),
       undefined
   end.
 


### PR DESCRIPTION
The first `io:format/2` call is non-informative and only pollutes console log making console output inconsistent. Probably it was just forgotten after debugging.
The second one is replaced with an error log message.