### PR TITLE
Add -std=c++11 compiler flag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,3 +6,4 @@
 {post_hooks,
   [{clean, "make clean"}]}.
 
+{port_env, [{"CFLAGS", "$CFLAGS -std=c++11"}]}.


### PR DESCRIPTION
The PR will fix the following error on old C++ compilers:
```
/usr/include/c++/4.7/atomic:598:7: error: ‘constexpr’ does not name a type
/usr/include/c++/4.7/atomic:598:7: note: C++11 ‘constexpr’ only available with -std=c++11 or -std=gnu++11
```